### PR TITLE
Added templateName option

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ module.exports = function (options) {
             var contents = file.contents.toString();
             var compiledFunction = ejs.compile(contents, options).toString();
             var templateName = typeof(options.templateName) === 'function' ? options.templateName(file.relative) : JSON.stringify(file.relative.slice(0, -4));
-            var prefix = templateVarName + '[' + templateName +'] = ';
+            var prefix = templateVarName + '["' + templateName +'"] = ';
             var suffix = ';'
             compiledFunction = prefix + compiledFunction + suffix;
             file.contents = new Buffer(compiledFunction);

--- a/index.js
+++ b/index.js
@@ -26,7 +26,8 @@ module.exports = function (options) {
         try {
             var contents = file.contents.toString();
             var compiledFunction = ejs.compile(contents, options).toString();
-            var prefix = templateVarName + '[' + JSON.stringify(file.relative.slice(0, -4)) +'] = ';
+            var templateName = typeof(options.templateName) === 'function' ? options.templateName(file.relative) : JSON.stringify(file.relative.slice(0, -4));
+            var prefix = templateVarName + '[' + templateName +'] = ';
             var suffix = ';'
             compiledFunction = prefix + compiledFunction + suffix;
             file.contents = new Buffer(compiledFunction);


### PR DESCRIPTION
I needed a way to (rename) change the array keys. When deploying on a different OS, the template key slashes would change breaking my code.
