### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,38 @@ A plugin for gulp that precompiles ejs templates
 
 
 ```js
-var ejs = require('gulp-ejs-precompiler');
+var ejsPrecompiler = require('gulp-ejs-precompiler');
 var concat = require('gulp-concat');
+var insert = require('gulp-insert');
+
+// Sample of task config
+var config = {
+    src: '/path/to/ejs/templates/*.ejs', // The ejs source files
+    dist: '/path/to/compiled/ejs/', // Path where the compiled file will be stored
+    filename: 'templates.js', // Name of the complied file
+    templateVarName: 'templates',
+};
 
 gulp.task('ejs', function() {
-    return gulp.src(paths.browser.templatesEJS)
-        .pipe(plumber())
-        .pipe(ejs({
-            compileDebug: true,
-            client: true
-        }))
-        .pipe(concat(pkg.name + /*'-' + pkg.version +*/ '.templates.js'))
-        .pipe(insert.prepend('window.templates = {};'+"\n"))
-        .pipe(gulp.dest(paths.dist));
+    return gulp.src(config.src)
+        .pipe(
+            ejsPrecompiler({
+                templateVarName: config.templateVarName,
+                compileDebug: true,
+                client: true,
+            }).on('error', function(err) {
+                console.log('EJS Precompiler error', err);
+                this.emit('end');
+            })
+        )
+        .pipe(concat(config.filename))
+        .pipe(insert.prepend('window.' + config.templateVarName + ' = {};'+"\n"))
+        .pipe(gulp.dest(config.dist));
 });
+```
+
+## Options
+
+- templateVarName (String): the javascript variable name
+
+_Others options are directly given to gulp ejs for compilation. See [gulp-ejs](https://www.npmjs.com/package/gulp-ejs) for more information._


### PR DESCRIPTION
- Put config outside to make it more clear for the usecase
- Add templateVarName use case to show it has to be changed in gulp-insert
- Remove plumber and use standard error management for example
- explicit options (templateVarName / gulp-ejs options)
