### PR TITLE
Allow other template source file extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ gulp.task('ejs', function() {
 
 ## Options
 
-- templateVarName (String): the javascript variable name
+- templateVarName (String): the javascript variable name. _Default: templates_
+- fileExtension (String): the template source file extension. _Default: .ejs_
 
 _Others options are directly given to gulp ejs for compilation. See [gulp-ejs](https://www.npmjs.com/package/gulp-ejs) for more information._

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = function (options) {
         try {
             var contents = file.contents.toString();
             var compiledFunction = ejs.compile(contents, options).toString();
-            var prefix = templateVarName + '[' + JSON.stringify(file.relative.slice(0, -1 * fileExtension.length)) +'] = ';
+            var prefix = templateVarName + '[' + JSON.stringify(file.relative.slice(0, -fileExtension.length)) +'] = ';
             var suffix = ';'
             compiledFunction = prefix + compiledFunction + suffix;
             file.contents = new Buffer(compiledFunction);

--- a/index.js
+++ b/index.js
@@ -8,6 +8,9 @@ module.exports = function (options) {
     var templateVarName = options.templateVarName || 'templates';
     delete options.templateVarName;
 
+    var fileExtension = options.fileExtension || '.ejs';
+    delete options.fileExtension;
+
     return through.obj(function (file, enc, next) {
         if (file.isNull()) {
             this.push(file);
@@ -26,14 +29,14 @@ module.exports = function (options) {
         try {
             var contents = file.contents.toString();
             var compiledFunction = ejs.compile(contents, options).toString();
-            var prefix = templateVarName + '[' + JSON.stringify(file.relative.slice(0, -4)) +'] = ';
+            var prefix = templateVarName + '[' + JSON.stringify(file.relative.slice(0, -1 * fileExtension.length)) +'] = ';
             var suffix = ';'
             compiledFunction = prefix + compiledFunction + suffix;
             file.contents = new Buffer(compiledFunction);
             file.path = gutil.replaceExtension(file.path, '.js');
         } catch (err) {
             this.emit('error', new gutil.PluginError('gulp-ejs-precompiler', err));
-         }
+        }
 
         this.push(file);
         next();

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
   "homepage": "https://github.com/christophehurpeau/gulp-ejs-precompiler",
   "license": "MIT",
   "author": "Christophe Hurpeau <christophe@hurpeau.com> (http://christophe.hurpeau.com/)",
+  "contributors": [
+    "Julien Tilap LA VINH <jlavinh@gmail.com> (http://tilap.net/)"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/christophehurpeau/gulp-ejs-precompiler.git"


### PR DESCRIPTION
- Add fileExtension option (default '.ejs').
- Update documentation
- Add contributor entry in package.json
